### PR TITLE
fix rsp_to core dump

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -3,7 +3,7 @@
 
 #include <chrono>
 
-#define VERSION "0.7.10-2017-02-28"
+#define VERSION "0.7.11-2017-03-29"
 
 namespace cerb {
 

--- a/core/client.cpp
+++ b/core/client.cpp
@@ -78,7 +78,9 @@ void Client::_send_buffer_set()
             g->collect_stats(this->_proxy);
         }
         this->_ready_groups.clear();
-        this->_peers.clear();
+        if (_awaiting_groups.empty()) {
+            this->_peers.clear();
+        }
         if (!this->_parsed_groups.empty()) {
             _process();
         }


### PR DESCRIPTION
当客户端以很小的超时时间发送命令时，很容易产生rsp_to 方法core dump. bt结果：
```
(gdb) bt
#0  0x0000003a47432625 in raise () from /lib64/libc.so.6
#1  0x0000003a47433e05 in abort () from /lib64/libc.so.6
#2  0x0000003a4a46007d in __gnu_cxx::__verbose_terminate_handler () at ../../.././libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x0000003a4a45e0e6 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../.././libstdc++-v3/libsupc++/eh_terminate.cc:47
#4  0x0000003a4a45e131 in std::terminate () at ../../.././libstdc++-v3/libsupc++/eh_terminate.cc:57
#5  0x000000000053dafc in handle_segv(int, siginfo*, void*) ()
#6  <signal handler called>
#7  0x00002ae888003400 in ?? ()
#8  0x000000000051f423 in (anonymous namespace)::NormalResponse::rsp_to (this=0x2ae88803b470, cmd=...) at core/response.cpp:30
#9  0x0000000000522d6a in cerb::Server::_recv_from (this=0x2ae8880c3d50) at core/server.cpp:86
#10 0x0000000000521b47 in cerb::Server::on_events (this=0x2ae8880c3d50, events=1) at core/server.cpp:27
#11 0x0000000000513371 in cerb::Proxy::handle_events (this=0x2ae884b05010, events=0x2ae884f65da0, nfds=4) at core/proxy.cpp:298
#12 0x0000000000506ba2 in operator() (this=0x119ec28) at core/concurrence.cpp:24
#13 0x0000000000506ae5 in std::_Bind_simple<cerb::ListenThread::run()::$_0 ()>::_M_invoke<>(std::_Index_tuple<>) (this=0x119ec28)
    at /usr/bin/../lib/gcc/x86_64-unknown-linux-gnu/4.9.3/../../../../include/c++/4.9.3/functional:1699
#14 0x0000000000506ab5 in std::_Bind_simple<cerb::ListenThread::run()::$_0 ()>::operator()() (this=0x119ec28)
    at /usr/bin/../lib/gcc/x86_64-unknown-linux-gnu/4.9.3/../../../../include/c++/4.9.3/functional:1688
#15 0x0000000000506a8c in std::thread::_Impl<std::_Bind_simple<cerb::ListenThread::run()::$_0 ()> >::_M_run() (this=0x119ec10)
    at /usr/bin/../lib/gcc/x86_64-unknown-linux-gnu/4.9.3/../../../../include/c++/4.9.3/thread:115
#16 0x0000003a4a4bb760 in std::(anonymous namespace)::execute_native_thread_routine (__p=<optimized out>)
    at ../../../.././libstdc++-v3/src/c++11/thread.cc:84
#17 0x0000003a47807aa1 in start_thread () from /lib64/libpthread.so.0
#18 0x0000003a474e893d in clone () from /lib64/libc.so.6
```

在添加了部分日志后发现，cerberus在旧命令的响应到来后把_peers变量清空了，而新命令的_peers在此之前就已经添加到了_peers里，结果客户端一旦突然断开，_peers为空，无法在Client析构方法里处理_sent_commands里失效的命令；等再处理_sent_commands命令准备移交响应时，command已经被析构

一种work around方式就是禁止在_awaiting_groups不为空时清空_peers，尽管可能会造成未被选中的Server变得可写，但不影响Server的状态，有命令就处理，没命令就相当于做了多余的on_events调用